### PR TITLE
NonProductFeed 페이지 생성 및 Pagination 구현

### DIFF
--- a/be/post/api.py
+++ b/be/post/api.py
@@ -15,20 +15,27 @@ from django.db import transaction
 
 
 @api_view(['GET'])
-def post_list(request):
+def product_list(request):
     category_name = request.GET.get('category', 'all')
+    posts = Post.objects.filter(content_type="product")
     
-    if category_name == 'all':
-        posts = Post.objects.all()
-    else:
+    if category_name != 'all':
         category = get_object_or_404(Category, name=category_name)
-        posts = Post.objects.filter(product__category=category)
+        posts = posts.filter(product__category=category)
     
     trend = request.GET.get('trend', '')
     if trend:
         posts = posts.filter(body__icontains='#' + trend)
         
     serializer = PostSerializer(posts, many=True)
+    return JsonResponse(serializer.data, safe=False)
+
+
+@api_view(['GET'])
+def post_list(request):
+    posts = Post.objects.filter(content_type__in=['post', 'review'])
+    
+    serializer = PostDetailSerializer(posts, many=True)
     return JsonResponse(serializer.data, safe=False)
 
 

--- a/be/post/api.py
+++ b/be/post/api.py
@@ -12,6 +12,11 @@ from rest_framework.decorators import api_view, authentication_classes, permissi
 from order.models import OrderItem
 import json
 from django.db import transaction
+from rest_framework.generics import ListAPIView
+from rest_framework.pagination import PageNumberPagination
+
+class PostListPagination(PageNumberPagination):
+    page_size = 3
 
 
 @api_view(['GET'])
@@ -31,12 +36,10 @@ def product_list(request):
     return JsonResponse(serializer.data, safe=False)
 
 
-@api_view(['GET'])
-def post_list(request):
-    posts = Post.objects.filter(content_type__in=['post', 'review'])
-    
-    serializer = PostDetailSerializer(posts, many=True)
-    return JsonResponse(serializer.data, safe=False)
+class PostListView(ListAPIView):
+    queryset = Post.objects.filter(content_type__in=['post', 'review'])
+    serializer_class = PostDetailSerializer
+    pagination_class = PostListPagination
 
 
 @api_view(['GET'])
@@ -187,7 +190,7 @@ def post_like(request, pk):
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])
 def check_liked(request, pk):
-    post = Post.objects.get(pk=pk)    
+    post = Post.objects.get(pk=pk)
     me = request.user
     is_liked = Like.objects.filter(created_by=me, post=post).exists()
     return JsonResponse({'isLiked': is_liked})

--- a/be/post/urls.py
+++ b/be/post/urls.py
@@ -3,7 +3,8 @@ from . import api
 
 # config path('api/posts/', include('post.urls')),
 urlpatterns = [
-    path('', api.post_list, name='post_list'),
+    path('', api.product_list, name='product_list'),
+    path('feed/', api.post_list, name='post_list'),
     path('profile/<uuid:id>/', api.post_list_profile, name='post_list_profile'),
     path('<uuid:pk>/', api.post_detail, name='post_detail'),
     

--- a/be/post/urls.py
+++ b/be/post/urls.py
@@ -4,7 +4,7 @@ from . import api
 # config path('api/posts/', include('post.urls')),
 urlpatterns = [
     path('', api.product_list, name='product_list'),
-    path('feed/', api.post_list, name='post_list'),
+    path('feed/', api.PostListView.as_view(), name='post_list'),
     path('profile/<uuid:id>/', api.post_list_profile, name='post_list_profile'),
     path('<uuid:pk>/', api.post_detail, name='post_detail'),
     

--- a/fe/src/App.vue
+++ b/fe/src/App.vue
@@ -14,11 +14,11 @@
                         </svg>
                     </RouterLink>
 
-                    <a href="#">
+                    <RouterLink to="/nonproductfeed" class="text-purple-700">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
                             <path stroke-linecap="round" stroke-linejoin="round" d="M8.625 9.75a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H8.25m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0H12m4.125 0a.375.375 0 11-.75 0 .375.375 0 01.75 0zm0 0h-.375m-13.5 3.01c0 1.6 1.123 2.994 2.707 3.227 1.087.16 2.185.283 3.293.369V21l4.184-4.183a1.14 1.14 0 01.778-.332 48.294 48.294 0 005.83-.498c1.585-.233 2.708-1.626 2.708-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z"></path>
                         </svg>                              
-                    </a>
+                    </RouterLink>
 
                     <RouterLink to="/crop" class="text-purple-700">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">

--- a/fe/src/router/index.js
+++ b/fe/src/router/index.js
@@ -14,6 +14,7 @@ import EditPasswordView from '../views/EditPasswordView.vue'
 import SalesView from '../views/SalesView.vue'
 import OrderPage from '../views/OrderPage.vue'
 import OrderHistory from '../views/OrderHistory.vue'
+import NonProductFeedView from '../views/NonProductFeedView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -27,6 +28,11 @@ const router = createRouter({
       path: '/feed',
       name: 'feed',
       component: FeedView
+    },
+    {
+      path: '/nonproductfeed',
+      name: 'nonproductfeed',
+      component: NonProductFeedView
     },
     {
       path: '/crop',

--- a/fe/src/views/NonProductFeedView.vue
+++ b/fe/src/views/NonProductFeedView.vue
@@ -51,6 +51,7 @@ export default {
 					this.posts.push(...response.data.results);
 					this.nextPageUrl = response.data.next;
 					this.isLoading = false;
+					console.log(this.posts)
 				})
 				.catch((error) => {
 					console.log('error', error);
@@ -63,7 +64,7 @@ export default {
 			const clientHeight = document.documentElement.clientHeight;
 
 			if (
-				scrollTop + clientHeight >= scrollHeight &&
+				Math.ceil(scrollTop + clientHeight) >= Math.floor(scrollHeight) &&
 				this.nextPageUrl &&
 				!this.isLoading
 			) {

--- a/fe/src/views/NonProductFeedView.vue
+++ b/fe/src/views/NonProductFeedView.vue
@@ -1,0 +1,56 @@
+<template>
+	<div class="max-w-7xl mx-auto grid grid-cols-4 gap-4" ref="content">
+		<div class="main-center col-span-3 space-y-4">
+
+			<div v-for="post in posts" :key="post.id"
+				class="p-4 bg-white border border-gray-200 rounded-lg">
+				<FeedItem :post="post" />
+			</div>
+		</div>
+		<div class="main-right col-span-1 space-y-4">
+
+			<Trends />
+		</div>
+	</div>
+</template>
+
+<script>
+import axios from 'axios';
+import Trends from '../components/Trends.vue';
+import FeedItem from '../components/FeedItem.vue';
+
+export default {
+	name: 'NonProductFeedView',
+
+	components: {
+		Trends,
+		FeedItem,
+	},
+
+	data() {
+		return {
+			posts: [],
+		}
+	},
+
+	mounted() {
+		this.getPost()
+	},
+
+	methods: {
+		getPost() {
+			axios
+				.get(`/api/posts/feed/`)
+				.then(response => {
+					console.log('data', response.data)
+
+					this.posts = response.data
+				})
+				.catch(error => {
+					console.log('error', error)
+				})
+		},
+	}
+}
+
+</script>


### PR DESCRIPTION
be
- post/api.py
- 페이지네이션 클라스 및 content_type=['post', 'review']인 포스트만 가져오는 PostListView 작성
- 기존 메소드명 post_list -> product_list로 변경, content_type="product"인 포스트만 반환

fe
- views/NonProductFeedView.vue 생성
- src/App.vue에 말풍선 아이콘에 페이지 라우팅
- 현재 NonProductFeedView에만 pagination 구현됨