### PR TITLE
FeedView pagination

### DIFF
--- a/be/post/api.py
+++ b/be/post/api.py
@@ -16,24 +16,27 @@ from rest_framework.generics import ListAPIView
 from rest_framework.pagination import PageNumberPagination
 
 class PostListPagination(PageNumberPagination):
-    page_size = 3
+    page_size = 6
 
 
-@api_view(['GET'])
-def product_list(request):
-    category_name = request.GET.get('category', 'all')
-    posts = Post.objects.filter(content_type="product")
-    
-    if category_name != 'all':
-        category = get_object_or_404(Category, name=category_name)
-        posts = posts.filter(product__category=category)
-    
-    trend = request.GET.get('trend', '')
-    if trend:
-        posts = posts.filter(body__icontains='#' + trend)
-        
-    serializer = PostSerializer(posts, many=True)
-    return JsonResponse(serializer.data, safe=False)
+class ProductListView(ListAPIView):
+    queryset = Post.objects.filter(content_type="product")
+    serializer_class = PostSerializer
+    pagination_class = PostListPagination
+
+    def get_queryset(self):
+        queryset = self.queryset
+        category_name = self.request.query_params.get('category', 'all')
+        trend = self.request.query_params.get('trend', '')
+
+        if category_name != 'all':
+            category = get_object_or_404(Category, name=category_name)
+            queryset = queryset.filter(product__category=category)
+
+        if trend:
+            queryset = queryset.filter(body__icontains='#' + trend)
+
+        return queryset
 
 
 class PostListView(ListAPIView):

--- a/be/post/urls.py
+++ b/be/post/urls.py
@@ -3,7 +3,7 @@ from . import api
 
 # config path('api/posts/', include('post.urls')),
 urlpatterns = [
-    path('', api.product_list, name='product_list'),
+    path('', api.ProductListView.as_view(), name='product_list'),
     path('feed/', api.PostListView.as_view(), name='post_list'),
     path('profile/<uuid:id>/', api.post_list_profile, name='post_list_profile'),
     path('<uuid:pk>/', api.post_detail, name='post_detail'),

--- a/fe/src/components/ScrollToTop.vue
+++ b/fe/src/components/ScrollToTop.vue
@@ -1,0 +1,25 @@
+<template>
+    <div class="fixed bottom-5 right-5">
+        <button @click="scrollToTop"
+            class="bg-white text-gray-700 rounded-full p-2 hover:bg-gray-200 border border-white-200">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                stroke="currentColor" class="w-5 h-5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 6.75 12 3m0 0 3.75 3.75M12 3v18" />
+            </svg>
+        </button>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'ScrollToTop',
+    methods: {
+        scrollToTop() {
+            window.scrollTo({
+                top: 0,
+                behavior: 'smooth'
+            });
+        }
+    }
+}
+</script>

--- a/fe/src/views/FeedView.vue
+++ b/fe/src/views/FeedView.vue
@@ -24,12 +24,14 @@
             <Trends />
         </div>
     </div>
+	<ScrollToTop></ScrollToTop>
 </template>
 
 <script>
 import axios from 'axios'
 import Trends from '../components/Trends.vue'
 import FeedListItem from '../components/FeedListItem.vue'
+import ScrollToTop from '../components/ScrollToTop.vue'
 
 export default {
     name: 'FeedView',
@@ -37,6 +39,7 @@ export default {
     components: {
         Trends,
         FeedListItem,
+        ScrollToTop,
     },
 
     data() {

--- a/fe/src/views/FeedView.vue
+++ b/fe/src/views/FeedView.vue
@@ -44,35 +44,78 @@ export default {
             posts: [],
             body: '',
             category: 'all',
+            nextPageUrl: null,
+            isLoading: false,
+            debouncedGetFeed: null,
         }
     },
 
     mounted() {
         this.getFeed('all')
+        this.initDebouncedGetFeed()
+        window.addEventListener('scroll', this.handleScroll)
     },
 
+	beforeDestroy() {
+		window.removeEventListener('scroll', this.handleScroll)
+	},
+
     methods: {
-        getFeed(category) {
-            let url = '/api/posts/';
+        initDebouncedGetFeed() {
+            this.debouncedGetFeed = this.debounce(this.getFeed, 100);
+        },
+        debounce(func, delay) {
+            let timeoutId;
+            return (...args) => {
+                clearTimeout(timeoutId);
+                timeoutId = setTimeout(() => {
+                func.apply(this, args);
+                }, delay);
+            };
+        },
+        getFeed(category, page = 1) {
+            if (this.isLoading) return;
+            this.isLoading = true;
+
+            let url = this.nextPageUrl || `/api/posts/?page=${page}`;
             if (category !== 'all') {
-                url += `?category=${category}`;
+                url += `&category=${category}`;
             }
 
             axios
                 .get(url)
                 .then(response => {
-                    console.log('data', response.data)
-
-                    this.posts = response.data
+                    this.posts.push(...response.data.results);
+                    this.nextPageUrl = response.data.next;
+                    this.isLoading = false;
+                    
+                    console.log('posts', this.posts)
                 })
                 .catch(error => {
                     console.log('error', error)
-                })
+                    this.isLoading = false;
+                });
+        },
+        handleScroll() {
+            const scrollHeight = document.documentElement.scrollHeight;
+            const scrollTop = document.documentElement.scrollTop;
+            const clientHeight = document.documentElement.clientHeight;
+
+            if (
+                Math.ceil(scrollTop + clientHeight) >= Math.floor(scrollHeight) &&
+                this.nextPageUrl &&
+                !this.isLoading
+            ) {
+                this.debouncedGetFeed(this.category);
+            }
         },
         categorizeProduct(category) {
             this.category = category
+            this.posts = []
+            this.nextPageUrl = null
+            this.isLoading = false;
             this.getFeed(category)
-        }
+        },
     }
 }
 </script>

--- a/fe/src/views/NonProductFeedView.vue
+++ b/fe/src/views/NonProductFeedView.vue
@@ -11,12 +11,15 @@
 			<Trends />
 		</div>
 	</div>
+	
+	<ScrollToTop></ScrollToTop>
 </template>
 
 <script>
 import axios from 'axios';
 import Trends from '../components/Trends.vue';
 import FeedItem from '../components/FeedItem.vue';
+import ScrollToTop from '../components/ScrollToTop.vue';
 
 export default {
 	name: 'NonProductFeedView',
@@ -24,6 +27,7 @@ export default {
 	components: {
 		Trends,
 		FeedItem,
+		ScrollToTop,
 	},
 
 	data() {

--- a/fe/src/views/NonProductFeedView.vue
+++ b/fe/src/views/NonProductFeedView.vue
@@ -39,6 +39,10 @@ export default {
 		window.addEventListener('scroll', this.handleScroll)
 	},
 
+	beforeDestroy() {
+		window.removeEventListener('scroll', this.handleScroll)
+	},
+	
 	methods: {
 		getPost(page) {
 			if (this.isLoading) return;


### PR DESCRIPTION
be
- post/api.py의 PostListPagination 사이즈 3 -> 6으로 수정
- 기존 product_list 메소드를 ProductListView(ListAPIView)로 수정

fe
- views/FeedView.vue에 NonProductFeedView에 구현된 무한스크롤 기능과 유사하게 적용
- debouncing으로 빠른 스크롤 이벤트로 인한 과도한 API 호출 방지
- FeedView와 NonProductFeedView에 이벤트 리스너 제거 추가