### PR TITLE
댓글 모달 구현

### DIFF
--- a/be/post/api.py
+++ b/be/post/api.py
@@ -44,6 +44,11 @@ class PostListView(ListAPIView):
     serializer_class = PostDetailSerializer
     pagination_class = PostListPagination
 
+    def get_queryset(self):
+        queryset = self.queryset
+        queryset = queryset.annotate(comments_count=Count('comments'))
+        return queryset
+
 
 @api_view(['GET'])
 def post_detail(request, pk):

--- a/fe/src/components/FeedItem.vue
+++ b/fe/src/components/FeedItem.vue
@@ -64,10 +64,41 @@
             </div>
             
             <div class="flex items-center space-x-2">
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 01-.923 1.785A5.969 5.969 0 006 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337z"></path>
-                </svg> 
+                <ModalView v-if="isModalViewed" @close-modal="isModalViewed = false">
+                <div class="modal-comment-container">
+                    <div class="comment-container">
+                        <div
+                            class="p-4 ml-6 bg-white border border-gray-200 rounded-lg"
+                            v-for="comment in post.comments"
+                            v-bind:key="comment.id"
+                        >
+                            <CommentItem v-bind:comment="comment" />
+                        </div>
+                    </div>
 
+                    <div class="comment-form-container">
+                    <div class="bg-white border border-gray-200 rounded-lg">
+                        <form v-on:submit.prevent="submitForm" method="post">
+                            <div class="p-4">  
+                                <textarea v-model="body" class="p-4 w-full bg-gray-100 rounded-lg" placeholder="What do you think?"></textarea>
+                            </div>
+
+                            <div class="p-4 border-t border-gray-100">
+                                <button class="inline-block py-4 px-6 bg-purple-600 text-white rounded-lg">Comment</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+                </div>
+                </ModalView>
+                <button v-if="isNonProduct" @click="isModalViewed = true" class="p-1 rounded-full">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 01-.923 1.785A5.969 5.969 0 006 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337z"></path>
+                    </svg> 
+                </button>
+                <svg v-if="!isNonProduct" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 01-.923 1.785A5.969 5.969 0 006 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337z"></path>
+                </svg> 
                 <div class="text-gray-500 text-xs">{{ post.comments_count }} comments</div>
             </div>
         </div>
@@ -84,14 +115,21 @@ import axios from 'axios'
 import { useUserStore } from '@/stores/user'
 import { useToastStore } from '@/stores/toast'
 import { Swiper, SwiperSlide } from 'swiper/vue';
-
+import ModalView from '../components/ModalView.vue';
+import CommentItem from '../components/CommentItem.vue'
 
 export default {
     components: {
            Swiper,
-           SwiperSlide
+           SwiperSlide,
+           ModalView,
+           CommentItem,
        },
     props: {
+        isNonProduct: {
+            type: Boolean,
+            required: true
+    },
         post: Object
     },
     setup() {
@@ -108,8 +146,9 @@ export default {
         return {
             isLiked: false,
             showOptionModal: false,
-            productQuantity: 1
-
+            productQuantity: 1,
+            isModalViewed: false,
+            body: ''
         }
     },
     
@@ -183,6 +222,25 @@ export default {
             }
             sessionStorage.setItem('cart', JSON.stringify(cart));
             this.toastStore.showToast(3000, '상품이 장바구니에 담겼습니다.', 'bg-blue-500');
+        },
+
+        submitForm() {
+            console.log('submitForm', this.body)
+
+            axios
+                .post(`/api/posts/${this.post.id}/comment/`, {
+                    'body': this.body
+                })
+                .then(response => {
+                    console.log('data', response.data)
+
+                    this.post.comments.push(response.data)
+                    this.post.comments_count += 1
+                    this.body = ''
+                })
+                .catch(error => {
+                    console.log('error', error)
+                })
         }
 
     }
@@ -211,5 +269,23 @@ export default {
   padding: 20px;
   box-sizing: border-box;
   z-index: 1001; 
+}
+.modal-comment-container {
+  width: 100%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+.comment-container {
+  flex: 1;
+  max-height: 400px;
+  overflow-y: auto;
+}
+.comment-form-container {
+  align-self: flex-end;
+  width: 100%;
+  max-width: 800px;
+  padding: 20px 0;
 }
 </style>

--- a/fe/src/components/FeedItem.vue
+++ b/fe/src/components/FeedItem.vue
@@ -68,7 +68,7 @@
                 <div class="modal-comment-container">
                     <div class="comment-container">
                         <div
-                            class="p-4 ml-6 bg-white border border-gray-200 rounded-lg"
+                            class="p-4 ml-6 bg-white border border-gray-200 rounded-lg mt-2"
                             v-for="comment in post.comments"
                             v-bind:key="comment.id"
                         >
@@ -278,14 +278,14 @@ export default {
   gap: 20px;
 }
 .comment-container {
-  flex: 1;
-  max-height: 400px;
+  height: 400px;
   overflow-y: auto;
+  padding: 10px 5px;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem; 
 }
 .comment-form-container {
   align-self: flex-end;
   width: 100%;
-  max-width: 800px;
-  padding: 20px 0;
 }
 </style>

--- a/fe/src/views/NonProductFeedView.vue
+++ b/fe/src/views/NonProductFeedView.vue
@@ -3,7 +3,7 @@
 		<div class="main-center col-span-3 space-y-4">
 
 			<div v-for="post in posts" :key="post.id" class="p-4 bg-white border border-gray-200 rounded-lg">
-				<FeedItem :post="post" />
+				<FeedItem :post="post" :is-non-product="isNonProduct"/>
 			</div>
 		</div>
 		<div class="main-right col-span-1 space-y-4">
@@ -35,6 +35,7 @@ export default {
 			posts: [],
 			nextPageUrl: null,
 			isLoading: false,
+			isNonProduct: true,
 		}
 	},
 

--- a/fe/src/views/PostView.vue
+++ b/fe/src/views/PostView.vue
@@ -58,7 +58,8 @@ export default {
                 id: null,
                 comments: []
             },
-            body: ''
+            body: '',
+            isNonProduct: false,
         }
     },
 


### PR DESCRIPTION
**NonProductFeedView에서 댓글 아이콘 눌렀을 때 모달로 댓글창 띄우기**

be
- post/api.py의 PostListView 클래스 쿼리셋 수정

fe
- components/FeedItem.vue에 댓글 아이콘 버튼으로 수정( isNonProduct = true 인 페이지(NonProductFeedView)에서만 버튼으로, false(PostView)면 버튼 X)
- 모달에 댓글 기능 적용